### PR TITLE
Fixed comments rendering in builds

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,12 +8,12 @@
         </div>
         {{- partial "footer.html" . -}}
 
-# Additions start here
+        <!--  Additions start here -->
         
         {{ if .Site.Params.Navbar.use }}
             {{- partial "navbar.html" . -}} 
         {{ end }}
         
-# Additions stop here
+        <!-- Additions stop here --> 
     </body>
 </html>


### PR DESCRIPTION
The comments were rendering in builds of the website. Changed the comments to HTML syntax to resolve the issue.