### PR TITLE
Fix invalid copy command in docs

### DIFF
--- a/docs/customize_terminal/customize_terminal.md
+++ b/docs/customize_terminal/customize_terminal.md
@@ -32,9 +32,9 @@ In order to customize the terminal, you need to edit the following files
 
 Copy it to `mysite/layouts`
 ```bash
-$mkdir -p ./layouts/partials
-$cp ./themes/hugo-theme-shell/layouts/index.html
-$cp ./themes/hugo-theme-shell/partials/typeIndex.html
+$ mkdir -p ./layouts/partials
+$ cp themes/hugo-theme-shell/layouts/index.html layouts/partials
+$ cp themes/hugo-theme-shell/partials/typeIndex.html layouts/partials
 ```
 
 ## 2. Edit file


### PR DESCRIPTION
`cp` commands expects a destination argument which was missing.

Running as it is, throws this error:

```bash
$ cp ./themes/hugo-theme-shell/layouts/index.html
cp: missing destination file operand after './themes/hugo-theme-shell/layouts/index.html'
Try 'cp --help' for more information.
```