### PR TITLE
fix: correct updated schema in URL

### DIFF
--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -29,7 +29,7 @@
 
 {{/*  Assume that ubuntu and retro do not exist in gogh.  */}}
 {{ $themeData := getJSON "https://raw.githubusercontent.com/Gogh-Co/Gogh/master/data/themes.json" }}
-{{ range $t := $themeData.themes }}
+{{ range $t := $themeData }}
     {{if eq $t.name $.Site.Params.Terminal.scheme }}
         {{ $terminal_style = printf "body{background:%s}body #terminal{color:%s}body #user{color:%s}body #dir{color:%s}body .Typewriter__cursor{color:%s}a{color:%s}" $t.background $t.cursor $t.color_03 $t.color_05 $t.cursor $t.cursor | safeCSS }}
     {{ end }}


### PR DESCRIPTION
fixes #54 which is currently breaking builds.  Essentially, the JSON was flattened to no longer have the themes key.